### PR TITLE
fix(checkbox): style when line wraps

### DIFF
--- a/src/components/shared/renderers/checkbox-styles.scss
+++ b/src/components/shared/renderers/checkbox-styles.scss
@@ -11,6 +11,7 @@
     border-radius: 25%;
     box-sizing: content-box !important;
     cursor: pointer;
+    flex-shrink: 0;
     height: 1em;
     margin-right: 5px;
     width: 1em;


### PR DESCRIPTION
This should fix that pesky issue when the checkbox shrinks.
Before:
![Screen Shot 2019-10-29 at 9 43 27 AM](https://user-images.githubusercontent.com/9825605/67777987-94015400-fa30-11e9-9ccc-ec697b956e79.png)

After:
![Screen Shot 2019-10-29 at 9 45 22 AM](https://user-images.githubusercontent.com/9825605/67778200-d88cef80-fa30-11e9-80f0-85805dcc5391.png)
