### PR TITLE
fix: use remark-breaks plugin for line breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^16.8.6",
     "react-markdown": "^4.2.2",
     "react-scripts": "3.0.1",
+    "remark-breaks": "^1.0.3",
     "stylelint": "^10.0.1",
     "stylelint-order": "^3.0.0",
     "uuid": "^3.3.2"

--- a/src/components/shared/markdown/Markdown.jsx
+++ b/src/components/shared/markdown/Markdown.jsx
@@ -1,6 +1,7 @@
 //@flow
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
+import breaks from 'remark-breaks';
 import Code from '../renderers/Code';
 import ListItem from '../renderers/ListItem';
 import {updateCheckbox} from './checkbox-helpers';
@@ -26,6 +27,7 @@ const Markdown = (props: Props) => {
       rawSourcePos={true}
       linkTarget="_blank"
       renderers={{code: Code, listItem: renderListItem}}
+      plugins={[breaks]}
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8982,6 +8982,11 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
+remark-breaks@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-1.0.3.tgz#9ca5dbf99ad04154bbf0b6e8f227b3735dfe637a"
+  integrity sha512-ip5hvJE8vsUJCGfgHaEJbf/JfO6KTZV+NBG68AWkEMhrjHW3Qh7EorED41mCt0FFSTrUDeRiNHovKO7cqgPZmw==
+
 remark-parse@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"


### PR DESCRIPTION
This is a regression from switching the markdown renderer. Line breaks should be good to go now!